### PR TITLE
Refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(n64-emu)
 
 set(SRC_FILES
     src/main.cpp
+    src/cpu/cpu.cpp
+    src/memory/memory.cpp
 )
 
 add_executable(n64 ${SRC_FILES})

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1,0 +1,9 @@
+#include "cpu.h"
+
+namespace N64 {
+
+Cpu n64cpu{};
+
+void foo() {}
+
+}

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <spdlog/spdlog.h>
 
 namespace N64 {
 
@@ -13,22 +14,26 @@ class Cpu {
     uint64_t pc;
     uint32_t gpr[NUM_GPR];
 
-    Cpu() : pc(0) {
+    Cpu() {}
+
+    void init() {
+        pc = 0;
         for (int i = 0; i < NUM_GPR; i++) {
             gpr[i] = 0;
         }
     }
 
     void dump() {
-        std::cout << "PC\t= 0x" << std::hex << pc << std::endl;
+        spdlog::info("PC = 0x{:x}", pc);
         for (int i = 0; i < NUM_GPR; i++) {
-            std::cout << "GPR[" << std::dec << i << "]\t= 0x" << std::hex
-                      << gpr[i] << std::endl;
+            spdlog::info("GPR[{}] = 0x{:x}", i, gpr[i]);
         }
     }
 };
 
-static Cpu n64cpu{};
+extern Cpu n64cpu;
+
+void foo();
 
 } // namespace N64
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,15 +11,19 @@ int main(int argc, char *argv[]) {
         std::cout << USAGE << std::endl;
         return -1;
     }
+    // ロガーのレベルをdebugに設定
+    spdlog::set_level(spdlog::level::debug);
+    // タイムスタンプが邪魔なのでカスタムのパターンを用いる
+    spdlog::set_pattern("[%l] %v");
 
     std::string filepath = {argv[1]};
+    
+    N64::n64cpu.init();
     N64::n64mem.init_with_rom(filepath);
 
     N64::pif_rom_execute();
 
     N64::n64cpu.dump();
 
-    spdlog::info("Welcome to spdlog!");
-    
     return 0;
 }

--- a/src/memory/memory.cpp
+++ b/src/memory/memory.cpp
@@ -1,0 +1,7 @@
+#include "memory.h"
+
+namespace N64 {
+    
+Memory n64mem {};
+
+}

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -1,8 +1,10 @@
 #ifndef MEMORY_H
 #define MEMORY_H
 
-#include "rom.h"
+#include <iostream>
 #include <cstdint>
+#include "rom.h"
+#include <spdlog/spdlog.h>
 
 namespace N64 {
 
@@ -16,12 +18,12 @@ class Memory {
     Memory() {}
 
     void init_with_rom(std::string rom_filepath) {
-        std::cout << "initializing RDRAM" << std::endl;
+        spdlog::debug("initializing RDRAM");
         rom.init(rom_filepath);
     }
 };
 
-static Memory n64mem;
+extern Memory n64mem;
 
 } // namespace N64
 

--- a/src/memory/rom.h
+++ b/src/memory/rom.h
@@ -5,6 +5,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <iostream>
+#include <spdlog/spdlog.h>
 #include <vector>
 
 namespace N64 {
@@ -42,27 +44,26 @@ class Rom {
     Rom() : rom({}), broken(true) {}
 
     void init(std::string filepath) {
-        std::cout << "reading ROM" << std::endl;
+        spdlog::debug("reading ROM");
 
         std::ifstream file(filepath.c_str(), std::ios::in | std::ios::binary);
         if (!file.is_open()) {
-            std::cout << "Could not open ROM file" << std::endl;
+            spdlog::error("Could not open ROM file");
             return;
         }
         rom = {std::istreambuf_iterator<char>(file),
                std::istreambuf_iterator<char>()};
 
         if (rom.size() < sizeof(rom_header_t)) {
-            std::cout << "ROM is too small" << std::endl;
+            spdlog::error("ROM is too small");
             return;
         }
 
         // set header
         header = *((rom_header_t *)rom.data());
 
-        std::cout << "ROM size\t= " << rom.size() << std::endl;
-        std::cout << "ROM imageName\t= " << header.image_name << std::endl;
-        std::cout << "ROM imageName\t= " << header.image_name << std::endl;
+        spdlog::debug("ROM size\t= {}", rom.size());
+        spdlog::debug("imageName\t= \"{}\"", std::string(header.image_name));
         broken = false;
     }
 


### PR DESCRIPTION
- n64cpuとn64memの定義をcppに移動
- ロガーの設定を変更
- std::coutをロギングに置き換え