### PR TITLE
Fix fmt strings

### DIFF
--- a/src/cpu/cop0.h
+++ b/src/cpu/cop0.h
@@ -160,7 +160,7 @@ class Cop0 {
 
     void dump() {
         for (int i = 0; i < 16; i++) {
-            spdlog::info("CP0[{}]\t= {:#016x}\tCP0[{}]\t= {:#016x}", i, reg[i],
+            spdlog::info("CP0[{}]\t= {:#018x}\tCP0[{}]\t= {:#018x}", i, reg[i],
                          i + 16, reg[i + 16]);
         }
     }

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -29,7 +29,7 @@ void Cpu::step() {
         case 0: // interrupt
         {
             spdlog::critical(
-                "Unimplemented. interruption IP = {:#07b} mask = {:#07b}",
+                "Unimplemented. interruption IP = {:#010b} mask = {:#010b}",
                 static_cast<uint32_t>(cop0.get_cause()->interrupt_pending),
                 static_cast<uint32_t>(cop0.get_status()->im));
             Utils::core_dump();
@@ -47,7 +47,7 @@ void Cpu::step() {
     uint32_t paddr_of_pc = Mmu::resolve_vaddr(pc);
     instruction_t inst;
     inst.raw = {Memory::read_paddr32(paddr_of_pc)};
-    spdlog::debug("fetched inst = {:#08x} from pc = {:#016x}", inst.raw, pc);
+    spdlog::debug("fetched inst = {:#010x} from pc = {:#018x}", inst.raw, pc);
 
     pc = next_pc;
     next_pc += 4;
@@ -127,7 +127,7 @@ void Cpu::execute_instruction(instruction_t inst) {
         } break;
         default: {
             spdlog::critical(
-                "Unimplemented funct = {:#06b} for opcode({:#06x}).",
+                "Unimplemented funct = {:#08b} for opcode = {:#08b}.",
                 static_cast<uint32_t>(inst.r_type.funct), op);
             Utils::core_dump();
             exit(-1);
@@ -195,7 +195,7 @@ void Cpu::execute_instruction(instruction_t inst) {
     {
         int64_t offset = (int16_t)inst.i_type.imm; // sext
         offset <<= 2;
-        spdlog::debug("BNE: {} != {}, pc + {:#x}", GPR_NAMES[inst.i_type.rs],
+        spdlog::debug("BNE: {} != {}, pc {:+#x}", GPR_NAMES[inst.i_type.rs],
                       GPR_NAMES[inst.i_type.rt], (int64_t)offset);
         branch(gpr.read(inst.i_type.rs) != gpr.read(inst.i_type.rt),
                pc + offset);
@@ -250,7 +250,7 @@ void Cpu::execute_instruction(instruction_t inst) {
         } break;
 
         default: {
-            spdlog::critical("Unimplemented CP0 inst. sub = {:05b}",
+            spdlog::critical("Unimplemented CP0 inst. sub = {:07b}",
                              static_cast<uint8_t>(inst.copz_type1.sub));
             Utils::core_dump();
             exit(-1);
@@ -258,7 +258,7 @@ void Cpu::execute_instruction(instruction_t inst) {
         }
     } break;
     default: {
-        spdlog::critical("Unimplemented opcode = {:#02x} ({:#06b})", op, op);
+        spdlog::critical("Unimplemented opcode = {:#04x} ({:#08b})", op, op);
         Utils::core_dump();
         exit(-1);
     }

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -95,7 +95,7 @@ class Cpu {
         spdlog::info("======= Core dump =======");
         spdlog::info("PC\t= {:#x}", pc);
         for (int i = 0; i < 16; i++) {
-            spdlog::info("{}\t= {:#016x}\t{}\t= {:#016x}", GPR_NAMES[i],
+            spdlog::info("{}\t= {:#018x}\t{}\t= {:#018x}", GPR_NAMES[i],
                          gpr.read(i), GPR_NAMES[i + 16], gpr.read(i + 16));
         }
         spdlog::info("");

--- a/src/cpu/instruction.h
+++ b/src/cpu/instruction.h
@@ -48,69 +48,6 @@ typedef union {
     } copz_type1;
 } instruction_t;
 
-/*
-const uint8_t mask5 = 0b11'111;
-const uint8_t mask6 = 0b11'1111;
-const uint16_t mask11 = 0b111'1111'1111;
-const uint16_t mask16 = 0b1111'1111'1111'1111;
-const uint8_t mask26 = 0x3FFFFFF;
-
-class Instruction {
-  public:
-    uint32_t raw;
-
-    uint8_t op;
-    // CPU instructions
-
-    // I-Type
-    uint8_t rs;
-    uint8_t rt;
-    uint16_t imm;
-    // J-Type
-    uint32_t target;
-    // R-Type
-    // rs
-    // rt
-    uint8_t rd;
-    uint8_t sa;
-    uint8_t funct;
-
-    // COP instructions
-    // Chapter 3.2.5 https://hack64.net/docs/VR43XX.pdf
-
-    // CP0 instructions
-    // Chapter 3.2.6 https://hack64.net/docs/VR43XX.pdf
-    uint8_t sub;
-    uint16_t should_be_zero;
-
-    // TODO: rest of COP instructions
-
-    Instruction(uint32_t big_endian_raw) {
-        raw = big_endian_raw;
-        op = (raw >> 26) & mask6;
-
-        // I-Type
-        rs = (raw >> 21) & mask5;
-        rt = (raw >> 16) & mask5;
-        imm = raw & mask16;
-        // J-Type
-        target = raw & mask26;
-        // R-Type
-        rd = (raw >> 11) & mask5;
-        sa = (raw >> 6) & mask5;
-        funct = raw & mask6;
-
-        // CP0
-        sub = (raw >> 21) & mask5;
-        // rt
-        // rd
-        should_be_zero = raw & mask11;
-
-        // TODO: rest of COP instructions
-    }
-};
-*/
-
 // MIPS instructions
 constexpr uint8_t OPCODE_SPECIAL = 0b000000;
 constexpr uint8_t OPCODE_COP0 = 0b010000;

--- a/src/memory/bus.h
+++ b/src/memory/bus.h
@@ -42,7 +42,7 @@ static uint8_t *get_pointer_to_paddr32(uint32_t paddr) {
     } else if (PHYS_ROM_BASE <= paddr && paddr <= PHYS_ROM_END) {
         return &n64mem.rom.raw()[paddr - PHYS_ROM_BASE];
     } else {
-        spdlog::critical("Unimplemented. access to paddr = {:#08x}", paddr);
+        spdlog::critical("Unimplemented. access to paddr = {:#010x}", paddr);
         Utils::core_dump();
         exit(-1);
     }

--- a/src/memory/ri.h
+++ b/src/memory/ri.h
@@ -45,7 +45,7 @@ class RI {
         case 0x0470'0008: // current_load
         case 0x0470'0014: // latency
         default: {
-            spdlog::critical("Unimplemented. Read from RI paddr = {:#08x}",
+            spdlog::critical("Unimplemented. Read from RI paddr = {:#010x}",
                              paddr);
             Utils::core_dump();
             exit(-1);

--- a/src/mmio/pi.h
+++ b/src/mmio/pi.h
@@ -36,7 +36,7 @@ class PI {
             return reinterpret_cast<uint8_t *>(&reg[reg_num]);
         } break;
         default: {
-            spdlog::critical("Unimplemented. Access to PI paddr = {:#08x}",
+            spdlog::critical("Unimplemented. Access to PI paddr = {:#010x}",
                              paddr);
             Utils::core_dump();
             exit(-1);

--- a/src/mmu/mmu.h
+++ b/src/mmu/mmu.h
@@ -36,11 +36,11 @@ static uint32_t resolve_vaddr(uint32_t vaddr) {
         // KSEG1はdirect mapped. baseを引くだけでよい
         paddr = vaddr - KSEG1_BASE;
     } else {
-        spdlog::debug("Unimplemented: address translation {:#08x}", vaddr);
+        spdlog::debug("Unimplemented: address translation {:#010x}", vaddr);
         Utils::core_dump();
         exit(-1);
     }
-    spdlog::trace("address translation vaddr {:#08x} => paddr {:#08x}", vaddr,
+    spdlog::trace("address translation vaddr {:#010x} => paddr {:#010x}", vaddr,
                   paddr);
     return paddr;
 }


### PR DESCRIPTION
uint32_tの数値を{:#016x}でフォーマットしていた箇所を{:#018x}に修正。
0xも長さに含まれるため。
他の基数のフォーマットも修正。