### PR TITLE
Add initial scheduler

### DIFF
--- a/src/mmio/pi.h
+++ b/src/mmio/pi.h
@@ -16,7 +16,16 @@ const uint32_t PADDR_RD_LEN = 0x04600008;
 const uint32_t PADDR_WR_LEN = 0x0460000C;
 const uint32_t PADDR_STATUS = 0x04600010;
 
+namespace PIScheduler {
+
+void on_dma_write_completed();
+
+}
+
 class PI {
+    // DMA write完了時の処理
+    friend void PIScheduler::on_dma_write_completed();
+
   private:
     uint32_t reg_dram_addr;
     uint32_t reg_cart_addr;
@@ -41,8 +50,6 @@ class PI {
     void dma_write();
 
     void dma_read();
-
-    void on_dma_write_completed();
 };
 
 } // namespace PI

--- a/src/n64_system/CMakeLists.txt
+++ b/src/n64_system/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_library(n64_system
-    n64_system.cpp n64_system.h config.cpp config.h)
+    n64_system.cpp n64_system.h
+    config.cpp config.h
+    scheduler.cpp scheduler.h)

--- a/src/n64_system/n64_system.cpp
+++ b/src/n64_system/n64_system.cpp
@@ -4,11 +4,14 @@
 #include "memory/pif.h"
 #include "mmio/pi.h"
 #include "rsp/rsp.h"
+#include "scheduler.h"
 
 namespace N64 {
 namespace N64System {
 
 void run(Config config) {
+    N64::g_scheduler().init();
+
     // Reset all processors
     N64::g_memory().load_rom(config.rom_filepath);
     N64::g_memory().reset();
@@ -30,7 +33,8 @@ void run(Config config) {
             N64::g_rsp().step();
             N64::g_rsp().step();
         }
-        // TODO: scheduling PI, VI, AI, SI, RI, DI, etc.
+
+        g_scheduler().tick(N64::Cpu::CPU_CYCLES_PER_INST);
     }
 }
 

--- a/src/n64_system/scheduler.cpp
+++ b/src/n64_system/scheduler.cpp
@@ -1,0 +1,13 @@
+﻿#include "scheduler.h"
+
+namespace N64 {
+namespace N64System {
+
+bool scheduled_event_compare(scheduled_event_t e, scheduled_event_t o) {
+    return e.first < o.first;
+}
+
+Scheduler Scheduler::instance{};
+
+} // namespace N64System
+} // namespace N64

--- a/src/n64_system/scheduler.h
+++ b/src/n64_system/scheduler.h
@@ -1,0 +1,84 @@
+﻿#ifndef SCHEDULER_H
+#define SCHEDULER_H
+
+#include "utils.h"
+#include <cstdint>
+#include <functional>
+#include <queue>
+#include <utility>
+#include <vector>
+
+namespace N64 {
+namespace N64System {
+
+class Event {
+  private:
+    std::function<void()> f;
+
+  public:
+    Event(std::function<void()> callback) : f(callback) {}
+
+    void perform() { f(); }
+};
+
+typedef std::pair<uint64_t, Event> scheduled_event_t;
+
+bool scheduled_event_compare(scheduled_event_t, scheduled_event_t);
+
+class Scheduler {
+  private:
+    static Scheduler instance;
+
+    // イベントのキュー. 要素は, イベントとそれが実行される時刻のペア
+    std::priority_queue<
+        scheduled_event_t, std::vector<scheduled_event_t>,
+        std::function<bool(scheduled_event_t, scheduled_event_t)>>
+        event_queue;
+
+    // 現在の時刻
+    uint64_t current_time;
+
+  public:
+    Scheduler() : current_time(0) {}
+
+    void init() { current_time = 0; }
+
+    // 現在からCPU cycles後にイベントを実行する
+    void set_timer(uint64_t cycles, Event event) {
+        event_queue.push({current_time + cycles, event});
+    }
+
+    // TODO: スケジューラ単体をテストしたほうがいい?
+    void tick(uint64_t cycles = 1) {
+        current_time += cycles;
+        // 少し余裕をもたせる
+        if (current_time > 0x0000'FFFF'FFFF'FFFF) {
+            // FIXME: fix this
+            Utils::unimplemented("current_time is reaching max");
+        }
+
+        while (!event_queue.empty()) {
+            // seek top event
+            scheduled_event_t e = event_queue.top();
+            if (e.first > current_time) {
+                return;
+            } else {
+                // pop an event from queue and perform it
+                event_queue.pop();
+                e.second.perform();
+            }
+        }
+    }
+
+    inline static Scheduler &get_instance() { return instance; }
+};
+
+} // namespace N64System
+
+inline N64System::Scheduler &g_scheduler() {
+    return N64System::Scheduler::get_instance();
+}
+
+} // namespace N64
+
+#endif


### PR DESCRIPTION
Addresses https://github.com/kmc-jp/n64-emu/issues/30

priority_queueを使って実装した。PI, VI, AI, etc.のDMAなどが頻繁に呼び出されると遅くなるかもので、高速化したい。