### PR TITLE
Refactor logger functions and add --log-level options

### DIFF
--- a/src/cpu/cpu_operation.cpp
+++ b/src/cpu/cpu_operation.cpp
@@ -1,7 +1,7 @@
 ﻿#include "cpu_operation.h"
-
 #include "bus.h"
 #include "mmu.h"
+#include "utils.h"
 
 namespace N64 {
 namespace Cpu {
@@ -17,10 +17,10 @@ class Cpu::Operation::Impl {
         // 分岐成立時のみ遅延スロットを実行する
         cpu.delay_slot = true; // FIXME: correct?
         if (cond) {
-            spdlog::debug("branch likely taken");
+            Utils::trace("branch likely taken");
             cpu.next_pc = vaddr;
         } else {
-            spdlog::debug("branch likely not taken");
+            Utils::trace("branch likely not taken");
             cpu.set_pc64(cpu.pc + 4);
         }
     }
@@ -28,10 +28,10 @@ class Cpu::Operation::Impl {
     static void branch_addr64(Cpu &cpu, bool cond, uint64_t vaddr) {
         cpu.delay_slot = true;
         if (cond) {
-            spdlog::debug("branch taken");
+            Utils::trace("branch taken");
             cpu.next_pc = vaddr;
         } else {
-            spdlog::debug("branch not taken");
+            Utils::trace("branch not taken");
         }
     }
 
@@ -39,14 +39,14 @@ class Cpu::Operation::Impl {
                                        instruction_t inst) {
         int64_t offset = (int16_t)inst.i_type.imm; // sext
         offset <<= 2;
-        spdlog::debug("pc <= pc {:+#x}?", (int64_t)offset);
+        Utils::trace("pc <= pc {:+#x}?", (int64_t)offset);
         branch_likely_addr64(cpu, cond, cpu.pc + offset);
     }
 
     static void branch_offset16(Cpu &cpu, bool cond, instruction_t inst) {
         int64_t offset = (int16_t)inst.i_type.imm; // sext
         offset <<= 2;
-        spdlog::debug("pc <= pc {:+#x}?", (int64_t)offset);
+        Utils::trace("pc <= pc {:+#x}?", (int64_t)offset);
         branch_addr64(cpu, cond, cpu.pc + offset);
     }
 
@@ -57,7 +57,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.r_type.sa == 0);
         uint64_t rs = cpu.gpr.read(inst.r_type.rs);
         uint64_t rt = cpu.gpr.read(inst.r_type.rt);
-        spdlog::debug("ADD: {} <= {} + {}", GPR_NAMES[inst.r_type.rd],
+        Utils::trace("ADD: {} <= {} + {}", GPR_NAMES[inst.r_type.rd],
                       GPR_NAMES[inst.r_type.rs], GPR_NAMES[inst.r_type.rt]);
         cpu.gpr.write(inst.r_type.rd, rs + rt);
     }
@@ -69,7 +69,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.r_type.sa == 0);
         uint64_t rs = cpu.gpr.read(inst.r_type.rs);
         uint64_t rt = cpu.gpr.read(inst.r_type.rt);
-        spdlog::debug("ADDU: {} <= {} + {}", GPR_NAMES[inst.r_type.rd],
+        Utils::trace("ADDU: {} <= {} + {}", GPR_NAMES[inst.r_type.rd],
                       GPR_NAMES[inst.r_type.rs], GPR_NAMES[inst.r_type.rt]);
         cpu.gpr.write(inst.r_type.rd, rs + rt);
     }
@@ -80,7 +80,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.r_type.sa == 0);
         uint64_t rs = cpu.gpr.read(inst.r_type.rs);
         uint64_t rt = cpu.gpr.read(inst.r_type.rt);
-        spdlog::debug("SUB: {} <= {} - {}", GPR_NAMES[inst.r_type.rd],
+        Utils::trace("SUB: {} <= {} - {}", GPR_NAMES[inst.r_type.rd],
                       GPR_NAMES[inst.r_type.rs], GPR_NAMES[inst.r_type.rt]);
         cpu.gpr.write(inst.r_type.rd, rs - rt);
     }
@@ -90,7 +90,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.r_type.sa == 0);
         uint64_t rs = cpu.gpr.read(inst.r_type.rs);
         uint64_t rt = cpu.gpr.read(inst.r_type.rt);
-        spdlog::debug("SUBU: {} <= {} - {}", GPR_NAMES[inst.r_type.rd],
+        Utils::trace("SUBU: {} <= {} - {}", GPR_NAMES[inst.r_type.rd],
                       GPR_NAMES[inst.r_type.rs], GPR_NAMES[inst.r_type.rt]);
         cpu.gpr.write(inst.r_type.rd, rs - rt);
     }
@@ -104,7 +104,7 @@ class Cpu::Operation::Impl {
         int32_t hi = (t >> 32) & 0xFFFFFFFF;
         int64_t sext_lo = lo; // sext
         int64_t sext_hi = hi; // sext
-        spdlog::debug("MULT {}, {}", GPR_NAMES[inst.r_type.rs],
+        Utils::trace("MULT {}, {}", GPR_NAMES[inst.r_type.rs],
                       GPR_NAMES[inst.r_type.rt]);
         cpu.lo = static_cast<uint64_t>(lo);
         cpu.hi = static_cast<uint64_t>(hi);
@@ -119,7 +119,7 @@ class Cpu::Operation::Impl {
         int32_t hi = (t >> 32) & 0xFFFFFFFF;
         int64_t sext_lo = lo; // sext
         int64_t sext_hi = hi; // sext
-        spdlog::debug("MULTU {}, {}", GPR_NAMES[inst.r_type.rs],
+        Utils::trace("MULTU {}, {}", GPR_NAMES[inst.r_type.rs],
                       GPR_NAMES[inst.r_type.rt]);
         cpu.lo = static_cast<uint64_t>(lo);
         cpu.hi = static_cast<uint64_t>(hi);
@@ -129,8 +129,12 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.r_type.rs == 0);
         uint64_t rt = cpu.gpr.read(inst.r_type.rt);
         uint8_t sa = inst.r_type.sa;
-        spdlog::debug("SLL: {} <= {} << {}", GPR_NAMES[inst.r_type.rd],
-                      GPR_NAMES[inst.r_type.rt], GPR_NAMES[inst.r_type.sa]);
+        if (inst.raw == 0) {
+            Utils::trace("NOP");
+        } else {
+            Utils::trace("SLL: {} <= {} << {}", GPR_NAMES[inst.r_type.rd],
+                          GPR_NAMES[inst.r_type.rt], GPR_NAMES[inst.r_type.sa]);
+        }
         cpu.gpr.write(inst.r_type.rd, rt << sa);
     }
 
@@ -138,7 +142,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.r_type.sa == 0);
         uint64_t rs = cpu.gpr.read(inst.r_type.rs); // unsigned
         uint64_t rt = cpu.gpr.read(inst.r_type.rt); // unsigned
-        spdlog::debug("SLTU {} {} {}", GPR_NAMES[inst.r_type.rd],
+        Utils::trace("SLTU {} {} {}", GPR_NAMES[inst.r_type.rd],
                       GPR_NAMES[inst.r_type.rt], GPR_NAMES[inst.r_type.sa]);
         if (rs < rt) {
             cpu.gpr.write(inst.r_type.rd, 1);
@@ -149,7 +153,7 @@ class Cpu::Operation::Impl {
 
     static void op_and(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.r_type.sa == 0);
-        spdlog::debug("AND: {} <= {} & {}", GPR_NAMES[inst.r_type.rd],
+        Utils::trace("AND: {} <= {} & {}", GPR_NAMES[inst.r_type.rd],
                       GPR_NAMES[inst.r_type.rs], GPR_NAMES[inst.r_type.rt]);
         cpu.gpr.write(inst.r_type.rd, cpu.gpr.read(inst.r_type.rs) &
                                           cpu.gpr.read(inst.r_type.rt));
@@ -157,7 +161,7 @@ class Cpu::Operation::Impl {
 
     static void op_or(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.r_type.sa == 0);
-        spdlog::debug("OR: {} <= {} | {}", GPR_NAMES[inst.r_type.rd],
+        Utils::trace("OR: {} <= {} | {}", GPR_NAMES[inst.r_type.rd],
                       GPR_NAMES[inst.r_type.rs], GPR_NAMES[inst.r_type.rt]);
         cpu.gpr.write(inst.r_type.rd, cpu.gpr.read(inst.r_type.rs) |
                                           cpu.gpr.read(inst.r_type.rt));
@@ -165,7 +169,7 @@ class Cpu::Operation::Impl {
 
     static void op_xor(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.r_type.sa == 0);
-        spdlog::debug("XOR: {} <= {} ^ {}", GPR_NAMES[inst.r_type.rd],
+        Utils::trace("XOR: {} <= {} ^ {}", GPR_NAMES[inst.r_type.rd],
                       GPR_NAMES[inst.r_type.rs], GPR_NAMES[inst.r_type.rt]);
         cpu.gpr.write(inst.r_type.rd, cpu.gpr.read(inst.r_type.rs) ^
                                           cpu.gpr.read(inst.r_type.rt));
@@ -175,21 +179,21 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.r_type.rt == 0 && inst.r_type.rd == 0 &&
                                  inst.r_type.sa == 0);
         uint64_t rs = cpu.gpr.read(inst.r_type.rs);
-        spdlog::debug("JR {}", GPR_NAMES[inst.r_type.rs]);
+        Utils::trace("JR {}", GPR_NAMES[inst.r_type.rs]);
         branch_addr64(cpu, true, rs);
     }
 
     static void op_mfhi(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.r_type.rs == 0 && inst.r_type.rt == 0 &&
                                  inst.r_type.sa == 0);
-        spdlog::debug("MFHI {} <= hi", GPR_NAMES[inst.r_type.rd]);
+        Utils::trace("MFHI {} <= hi", GPR_NAMES[inst.r_type.rd]);
         cpu.gpr.write(inst.r_type.rd, cpu.hi);
     }
 
     static void op_mflo(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.r_type.rs == 0 && inst.r_type.rt == 0 &&
                                  inst.r_type.sa == 0);
-        spdlog::debug("MFLO {} <= lo", GPR_NAMES[inst.r_type.rd]);
+        Utils::trace("MFLO {} <= lo", GPR_NAMES[inst.r_type.rd]);
         cpu.gpr.write(inst.r_type.rd, cpu.lo);
     }
 
@@ -197,13 +201,13 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.i_type.rs == 0);
         int64_t simm = (int16_t)inst.i_type.imm; // sext
         simm <<= 16;
-        spdlog::debug("LUI: {} <= {:#x}", GPR_NAMES[inst.i_type.rt], simm);
+        Utils::trace("LUI: {} <= {:#x}", GPR_NAMES[inst.i_type.rt], simm);
         cpu.gpr.write(inst.i_type.rt, simm);
     }
 
     static void op_lw(Cpu &cpu, instruction_t inst) {
         int64_t offset = (int16_t)inst.i_type.imm; // sext
-        spdlog::debug("LW: {} <= *({} + {:#x})", GPR_NAMES[inst.i_type.rt],
+        Utils::trace("LW: {} <= *({} + {:#x})", GPR_NAMES[inst.i_type.rt],
                       GPR_NAMES[inst.i_type.rs], offset);
         uint64_t vaddr = cpu.gpr.read(inst.i_type.rs) + offset;
         uint32_t paddr = Mmu::resolve_vaddr(vaddr);
@@ -213,7 +217,7 @@ class Cpu::Operation::Impl {
 
     static void op_sw(Cpu &cpu, instruction_t inst) {
         int64_t offset = (int16_t)inst.i_type.imm; // sext
-        spdlog::debug("SW: *({} + {:#x}) <= {}", GPR_NAMES[inst.i_type.rs],
+        Utils::trace("SW: *({} + {:#x}) <= {}", GPR_NAMES[inst.i_type.rs],
                       offset, GPR_NAMES[inst.r_type.rt]);
         uint64_t vaddr = cpu.gpr.read(inst.i_type.rs) + offset;
         uint32_t paddr = Mmu::resolve_vaddr(vaddr);
@@ -224,34 +228,34 @@ class Cpu::Operation::Impl {
     static void op_addiu(Cpu &cpu, instruction_t inst) {
         int64_t imm = (int16_t)inst.i_type.imm; // sext
         int64_t tmp = cpu.gpr.read(inst.i_type.rs) + imm;
-        spdlog::debug("ADDIU: {} <= {} + {:#x}", GPR_NAMES[inst.i_type.rt],
+        Utils::trace("ADDIU: {} <= {} + {:#x}", GPR_NAMES[inst.i_type.rt],
                       GPR_NAMES[inst.i_type.rs], imm);
         cpu.gpr.write(inst.i_type.rt, tmp);
     }
 
     static void op_andi(Cpu &cpu, instruction_t inst) {
         uint64_t imm = inst.i_type.imm; // zext
-        spdlog::debug("ANDI: {} <= {} & {:#x}", GPR_NAMES[inst.i_type.rt],
+        Utils::trace("ANDI: {} <= {} & {:#x}", GPR_NAMES[inst.i_type.rt],
                       GPR_NAMES[inst.i_type.rs], imm);
         cpu.gpr.write(inst.i_type.rt, cpu.gpr.read(inst.i_type.rs) & imm);
     }
 
     static void op_ori(Cpu &cpu, instruction_t inst) {
         uint64_t imm = inst.i_type.imm; // zext
-        spdlog::debug("ORI: {} <= {} | {:#x}", GPR_NAMES[inst.i_type.rt],
+        Utils::trace("ORI: {} <= {} | {:#x}", GPR_NAMES[inst.i_type.rt],
                       GPR_NAMES[inst.i_type.rs], imm);
         cpu.gpr.write(inst.i_type.rt, cpu.gpr.read(inst.i_type.rs) | imm);
     }
 
     static void op_xori(Cpu &cpu, instruction_t inst) {
         uint64_t imm = inst.i_type.imm; // zext
-        spdlog::debug("XORI: {} <= {} ^ {:#x}", GPR_NAMES[inst.i_type.rt],
+        Utils::trace("XORI: {} <= {} ^ {:#x}", GPR_NAMES[inst.i_type.rt],
                       GPR_NAMES[inst.i_type.rs], imm);
         cpu.gpr.write(inst.i_type.rt, cpu.gpr.read(inst.i_type.rs) ^ imm);
     }
 
     static void op_beq(Cpu &cpu, instruction_t inst) {
-        spdlog::debug("BEQ: cond {} == {}", GPR_NAMES[inst.i_type.rs],
+        Utils::trace("BEQ: cond {} == {}", GPR_NAMES[inst.i_type.rs],
                       GPR_NAMES[inst.i_type.rt]);
         branch_offset16(
             cpu, cpu.gpr.read(inst.i_type.rs) == cpu.gpr.read(inst.i_type.rt),
@@ -259,7 +263,7 @@ class Cpu::Operation::Impl {
     }
 
     static void op_beql(Cpu &cpu, instruction_t inst) {
-        spdlog::debug("BEQL: cond {} == {}", GPR_NAMES[inst.i_type.rs],
+        Utils::trace("BEQL: cond {} == {}", GPR_NAMES[inst.i_type.rs],
                       GPR_NAMES[inst.i_type.rt]);
         branch_likely_offset16(
             cpu, cpu.gpr.read(inst.i_type.rs) == cpu.gpr.read(inst.i_type.rt),
@@ -267,7 +271,7 @@ class Cpu::Operation::Impl {
     }
 
     static void op_bne(Cpu &cpu, instruction_t inst) {
-        spdlog::debug("BNE: cond {} != {}", GPR_NAMES[inst.i_type.rs],
+        Utils::trace("BNE: cond {} != {}", GPR_NAMES[inst.i_type.rs],
                       GPR_NAMES[inst.i_type.rt]);
         branch_offset16(
             cpu, cpu.gpr.read(inst.i_type.rs) != cpu.gpr.read(inst.i_type.rt),
@@ -275,7 +279,7 @@ class Cpu::Operation::Impl {
     }
 
     static void op_bnel(Cpu &cpu, instruction_t inst) {
-        spdlog::debug("BNEL: cond {} != {}", GPR_NAMES[inst.i_type.rs],
+        Utils::trace("BNEL: cond {} != {}", GPR_NAMES[inst.i_type.rs],
                       GPR_NAMES[inst.i_type.rt]);
         branch_likely_offset16(
             cpu, cpu.gpr.read(inst.i_type.rs) != cpu.gpr.read(inst.i_type.rt),
@@ -286,7 +290,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.i_type.rt == 0);
         // TODO: 32bit mode
         int64_t rs = cpu.gpr.read(inst.i_type.rs); // as signed integer
-        spdlog::debug("BLEZ: cond {} <= 0", GPR_NAMES[inst.i_type.rs]);
+        Utils::trace("BLEZ: cond {} <= 0", GPR_NAMES[inst.i_type.rs]);
         branch_offset16(cpu, rs < 0, inst);
     }
 
@@ -294,7 +298,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.i_type.rt == 0);
         // TODO: 32bit mode
         int64_t rs = cpu.gpr.read(inst.i_type.rs); // as signed integer
-        spdlog::debug("BLEZL: cond {} <= 0", GPR_NAMES[inst.i_type.rs]);
+        Utils::trace("BLEZL: cond {} <= 0", GPR_NAMES[inst.i_type.rs]);
         branch_likely_offset16(cpu, rs < 0, inst);
     }
 
@@ -302,7 +306,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.i_type.rt == 0);
         // TODO: 32bit mode
         int64_t rs = cpu.gpr.read(inst.i_type.rs); // as signed integer
-        spdlog::debug("BGTZ: cond {} > 0", GPR_NAMES[inst.i_type.rs]);
+        Utils::trace("BGTZ: cond {} > 0", GPR_NAMES[inst.i_type.rs]);
         branch_offset16(cpu, rs > 0, inst);
     }
 
@@ -310,7 +314,7 @@ class Cpu::Operation::Impl {
         assert_encoding_is_valid(inst.i_type.rt == 0);
         // TODO: 32bit mode
         int64_t rs = cpu.gpr.read(inst.i_type.rs); // as signed integer
-        spdlog::debug("BGTZL: cond {} > 0", GPR_NAMES[inst.i_type.rs]);
+        Utils::trace("BGTZL: cond {} > 0", GPR_NAMES[inst.i_type.rs]);
         branch_likely_offset16(cpu, rs > 0, inst);
     }
 
@@ -318,12 +322,12 @@ class Cpu::Operation::Impl {
         // B.1.1 CACHE Instruction
         // https://hack64.net/docs/VR43XX.pdf
         // no need for emulation?
-        spdlog::debug("CACHE: no effect");
+        Utils::trace("CACHE: no effect");
     }
 
     static void op_mfc0(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.copz_type1.should_be_zero == 0);
-        spdlog::debug("MFC0: {} <= COP0.reg[{}]", GPR_NAMES[inst.copz_type1.rt],
+        Utils::trace("MFC0: {} <= COP0.reg[{}]", GPR_NAMES[inst.copz_type1.rt],
                       static_cast<uint32_t>(inst.copz_type1.rd));
         int32_t tmp = cpu.cop0.reg.read(inst.copz_type1.rd);
         int64_t stmp = tmp; // sext
@@ -333,7 +337,7 @@ class Cpu::Operation::Impl {
 
     static void op_mtc0(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.copz_type1.should_be_zero == 0);
-        spdlog::debug("MTC0: COP0.reg[{}] <= {}",
+        Utils::trace("MTC0: COP0.reg[{}] <= {}",
                       static_cast<uint32_t>(inst.copz_type1.rd),
                       GPR_NAMES[inst.copz_type1.rt]);
         uint64_t tmp = cpu.gpr.read(inst.copz_type1.rt);
@@ -343,7 +347,7 @@ class Cpu::Operation::Impl {
 
     static void op_dmfc0(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.copz_type1.should_be_zero == 0);
-        spdlog::debug("DMFC0: {} <= COP0.reg[{}]",
+        Utils::trace("DMFC0: {} <= COP0.reg[{}]",
                       GPR_NAMES[inst.copz_type1.rt],
                       static_cast<uint32_t>(inst.copz_type1.rd));
         const uint64_t tmp = cpu.cop0.reg.read(inst.copz_type1.rd);
@@ -353,7 +357,7 @@ class Cpu::Operation::Impl {
 
     static void op_dmtc0(Cpu &cpu, instruction_t inst) {
         assert_encoding_is_valid(inst.copz_type1.should_be_zero == 0);
-        spdlog::debug("DMTC0: COP0.reg[{}] <= {}",
+        Utils::trace("DMTC0: COP0.reg[{}] <= {}",
                       static_cast<uint32_t>(inst.copz_type1.rd),
                       GPR_NAMES[inst.copz_type1.rt]);
         const uint64_t tmp = cpu.gpr.read(inst.copz_type1.rt);
@@ -397,7 +401,7 @@ void Cpu::Operation::execute(Cpu &cpu, instruction_t inst) {
         case SPECIAL_FUNCT_MFLO: // MFLO
             return Impl::op_mflo(cpu, inst);
         default:
-            spdlog::critical(
+            Utils::critical(
                 "Unimplemented funct = {:#08b} for opcode = {:#08b}.",
                 static_cast<uint32_t>(inst.r_type.funct), op);
             Utils::core_dump();
@@ -451,14 +455,14 @@ void Cpu::Operation::execute(Cpu &cpu, instruction_t inst) {
         case CP0_SUB_DMT: // DMTC0 (COPZ format)
             return Impl::op_dmtc0(cpu, inst);
         default:
-            spdlog::critical("Unimplemented CP0 inst. sub = {:07b}",
+            Utils::critical("Unimplemented CP0 inst. sub = {:07b}",
                              static_cast<uint8_t>(inst.copz_type1.sub));
             Utils::core_dump();
             exit(-1);
         }
     }
     default: {
-        spdlog::critical("Unimplemented opcode = {:#04x} ({:#08b})", op, op);
+        Utils::critical("Unimplemented opcode = {:#04x} ({:#08b})", op, op);
         Utils::core_dump();
         exit(-1);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,12 +22,7 @@ int main(int argc, char *argv[]) {
     if (config.log_filepath.empty() == false) {
         Utils::set_log_file(config.log_filepath);
     }
-
-    // set logger level
-    spdlog::set_level(spdlog::level::trace);
-    // use custom logging pattern
-    // https://github.com/gabime/spdlog/issues/2073
-    spdlog::set_pattern("[%^%l%$] %v");
+    Utils::set_log_level(config.log_level);
 
     N64::N64System::run(config);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,14 @@
 ﻿#include "config.h"
-#include "n64_system/n64_system.h"
 #include "n64_system/config.h"
-#include <iostream>
+#include "n64_system/n64_system.h"
 #include "utils.h"
+#include <iostream>
 
-constexpr std::string_view USAGE = "Usage: n64 [options] <ROM.z64>\n"
-                                   "Options:\n"
-                                   "--log <file>\tspecify output log file\n";
+constexpr std::string_view USAGE =
+    "Usage: n64 [options] <ROM.z64>\n"
+    "Options:\n"
+    "--log <file>\tspecify output log file(default to stdout)\n"
+    "--log-level [trace|debug|info|critical|off]\tset log level(default to debug)\n";
 
 int main(int argc, char *argv[]) {
     N64::N64System::Config config{};
@@ -16,6 +18,7 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
+    Utils::init_logger();
     if (config.log_filepath.empty() == false) {
         Utils::set_log_file(config.log_filepath);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,8 @@
 ﻿#include "config.h"
 #include "n64_system/n64_system.h"
 #include "n64_system/config.h"
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/spdlog.h>
 #include <iostream>
+#include "utils.h"
 
 constexpr std::string_view USAGE = "Usage: n64 [options] <ROM.z64>\n"
                                    "Options:\n"
@@ -18,8 +17,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (config.log_filepath.empty() == false) {
-        set_default_logger(
-            spdlog::basic_logger_mt("basic_logger", config.log_filepath, true));
+        Utils::set_log_file(config.log_filepath);
     }
 
     // set logger level

--- a/src/memory/rom.cpp
+++ b/src/memory/rom.cpp
@@ -47,7 +47,7 @@ CicType checksum_to_cic(uint32_t checksum) {
                                                  : CicType::CIC_UNKNOWN;
 
     if (result == CicType::CIC_UNKNOWN) {
-        spdlog::error("invalid checksum: {:#08x}", checksum);
+        Utils::abort("invalid checksum: {:#08x}", checksum);
     }
 
     return result;
@@ -55,7 +55,7 @@ CicType checksum_to_cic(uint32_t checksum) {
 
 void Rom::read_from(const std::string &filepath) {
 
-    spdlog::debug("reading from ROM");
+    Utils::debug("reading from ROM");
 
     std::ifstream file(filepath.c_str(), std::ios::in | std::ios::binary);
     if (!file.is_open()) {
@@ -69,7 +69,7 @@ void Rom::read_from(const std::string &filepath) {
     rom.resize(0xF000'0000);
 
     if (rom.size() < sizeof(rom_header_t)) {
-        spdlog::error("ROM is too small");
+        Utils::abort("ROM is too small");
         return;
     }
 
@@ -80,9 +80,9 @@ void Rom::read_from(const std::string &filepath) {
     const uint32_t checksum = crc32(0, &rom[0x40], 0x9C0);
     cic = checksum_to_cic(checksum);
 
-    spdlog::debug("ROM size\t= {}", rom.size());
-    spdlog::debug("imageName\t= \"{}\"", std::string(header.image_name));
-    spdlog::debug("CIC\t= {}", static_cast<int>(cic));
+    Utils::debug("ROM size\t= {}", rom.size());
+    Utils::debug("imageName\t= \"{}\"", std::string(header.image_name));
+    Utils::debug("CIC\t= {}", static_cast<int>(cic));
 
     broken = false;
 }

--- a/src/memory/rom.cpp
+++ b/src/memory/rom.cpp
@@ -1,4 +1,5 @@
 #include "rom.h"
+#include "utils.h"
 
 namespace N64 {
 namespace Memory {
@@ -58,7 +59,7 @@ void Rom::read_from(const std::string &filepath) {
 
     std::ifstream file(filepath.c_str(), std::ios::in | std::ios::binary);
     if (!file.is_open()) {
-        spdlog::error("Could not open ROM file");
+        Utils::abort("Could not open ROM file: {}", filepath);
         return;
     }
     rom = {std::istreambuf_iterator<char>(file),

--- a/src/memory/rom.h
+++ b/src/memory/rom.h
@@ -6,7 +6,6 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <spdlog/spdlog.h>
 #include <vector>
 
 namespace N64 {

--- a/src/n64_system/config.cpp
+++ b/src/n64_system/config.cpp
@@ -1,4 +1,6 @@
 ﻿#include "config.h"
+#include "utils.h"
+#include <iostream>
 #include <string>
 
 namespace N64 {
@@ -8,19 +10,48 @@ bool read_config_from_command_line(Config &config, int argc, char *argv[]) {
     if (argc < 2)
         return false;
 
+    // default to debug
+    config.log_level = Utils::LogLevel::DEBUG;
+
     for (int i = 1; i < argc; ++i) {
-        if (const std::string_view read = argv[i]; read == "--log") {
+        const std::string_view current = argv[i];
+        if (current == "--log") {
             // ログファイル指定
-            if (config.log_filepath.empty() == false)
+            if (config.log_filepath.empty() == false) {
+                std::cerr << "Error: log file already specified" << std::endl;
                 return false;
+            }
             config.log_filepath = argv[i + 1];
             i++;
-        } else if (read.empty() == false && read[0] != '-') {
-            // ROMパス指定
-            if (config.rom_filepath.empty() == false)
+        } else if (current == "--log-level") {
+            // ログレベル指定
+            std::string_view level_str = argv[i + 1];
+            if (level_str == "debug")
+                config.log_level = Utils::LogLevel::DEBUG;
+            else if (level_str == "info")
+                config.log_level = Utils::LogLevel::INFO;
+            else if (level_str == "trace")
+                config.log_level = Utils::LogLevel::TRACE;
+            else if (level_str == "critical")
+                config.log_level = Utils::LogLevel::CRITICAL;
+            else if (level_str == "off")
+                config.log_level = Utils::LogLevel::OFF;
+            else {
+                std::cerr << "Error: unknown log level `" << level_str << "`"
+                          << std::endl;
                 return false;
-            config.rom_filepath = read;
+            }
+            i++;
+        } else if (current.empty() == false && !current.starts_with('-')) {
+            // ROMパス指定
+            if (config.rom_filepath.empty() == false) {
+                std::cerr << "Error: ROM file already specified" << std::endl;
+                return false;
+            }
+            config.rom_filepath = current;
         } else {
+            std::cerr << "Error: unknown argument `" << current << "`"
+                      << std::endl;
             return false;
         }
     }

--- a/src/n64_system/config.h
+++ b/src/n64_system/config.h
@@ -2,6 +2,7 @@
 #define CONFIG_H
 
 #include <string>
+#include "utils.h"
 
 namespace N64 {
 namespace N64System {
@@ -9,6 +10,7 @@ namespace N64System {
 struct Config {
     std::string rom_filepath{};
     std::string log_filepath{};
+    Utils::LogLevel log_level;
 };
 
 bool read_config_from_command_line(Config &config, int argc, char *argv[]);

--- a/src/n64_system/n64_system.cpp
+++ b/src/n64_system/n64_system.cpp
@@ -10,6 +10,7 @@ namespace N64 {
 namespace N64System {
 
 void run(Config config) {
+    Utils::info("Resetting N64 system");
     N64::g_scheduler().init();
 
     // Reset all processors
@@ -20,8 +21,10 @@ void run(Config config) {
     N64::g_pi().reset();
 
     // PIF ROM execution
+    Utils::info("Executing PIF ROM");
     N64::Memory::pif_rom_execute();
 
+    Utils::info("Starting N64 system");
     int consumed_cpu_cycles = 0;
     while (true) {
         N64::g_cpu().step();

--- a/src/rsp/rsp.h
+++ b/src/rsp/rsp.h
@@ -1,8 +1,7 @@
 ﻿#ifndef RSP_H
 #define RSP_H
 
-#include <cstdint>
-#include <spdlog/spdlog.h>
+#include "utils/utils.h"
 
 namespace N64 {
 namespace Rsp {
@@ -20,7 +19,7 @@ class Rsp {
     Rsp() {}
 
     void reset() {
-        spdlog::debug("initializing RSP");
+        Utils::info("resetting RSP");
         // TODO: what should be done?
     }
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,6 +1,7 @@
 ﻿#include "cpu/cpu.h"
 #include <cstdint>
 #include <source_location>
+#include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
 
 namespace Utils {
@@ -24,11 +25,42 @@ void core_dump() { N64::g_cpu().dump(); }
 
 void unimplemented(const std::string what, const std::source_location loc) {
     spdlog::critical("Unimplemented. {}", what);
-    spdlog::critical("In `{}` at {}:({},{})",
-                     loc.function_name(), loc.file_name(), loc.line(),
-                     loc.column());
+    spdlog::critical("In `{}` at {}:({},{})", loc.function_name(),
+                     loc.file_name(), loc.line(), loc.column());
     core_dump();
     exit(-1);
+}
+
+void init_logger() { spdlog::set_pattern("[%^%l%$] %v"); }
+
+void set_log_file(std::string filepath) {
+    set_default_logger(
+        spdlog::basic_logger_mt("basic_logger", filepath, true));
+}
+
+void set_log_level(LogLevel level) {
+    spdlog::level::level_enum log_level;
+    switch (level) {
+    case LogLevel::Trace: {
+        log_level = spdlog::level::trace;
+    } break;
+    case LogLevel::Debug: {
+        log_level = spdlog::level::debug;
+    } break;
+    case LogLevel::Info: {
+        log_level = spdlog::level::info;
+    } break;
+    case LogLevel::Critical: {
+        log_level = spdlog::level::critical;
+    } break;
+    case LogLevel::Off: {
+        log_level = spdlog::level::off;
+    } break;
+    default: {
+        log_level = spdlog::level::off;
+    } break;
+    }
+    spdlog::set_level(log_level);
 }
 
 } // namespace Utils

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -34,26 +34,25 @@ void unimplemented(const std::string what, const std::source_location loc) {
 void init_logger() { spdlog::set_pattern("[%^%l%$] %v"); }
 
 void set_log_file(std::string filepath) {
-    set_default_logger(
-        spdlog::basic_logger_mt("basic_logger", filepath, true));
+    set_default_logger(spdlog::basic_logger_mt("basic_logger", filepath, true));
 }
 
 void set_log_level(LogLevel level) {
     spdlog::level::level_enum log_level;
     switch (level) {
-    case LogLevel::Trace: {
+    case LogLevel::TRACE: {
         log_level = spdlog::level::trace;
     } break;
-    case LogLevel::Debug: {
+    case LogLevel::DEBUG: {
         log_level = spdlog::level::debug;
     } break;
-    case LogLevel::Info: {
+    case LogLevel::INFO: {
         log_level = spdlog::level::info;
     } break;
-    case LogLevel::Critical: {
+    case LogLevel::CRITICAL: {
         log_level = spdlog::level::critical;
     } break;
-    case LogLevel::Off: {
+    case LogLevel::OFF: {
         log_level = spdlog::level::off;
     } break;
     default: {

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -2,8 +2,9 @@
 #define UTILS_H
 
 #include <cstdint>
-#include <string>
 #include <source_location>
+#include <spdlog/spdlog.h>
+#include <string>
 
 // PACK
 #ifdef __GNUC__
@@ -25,7 +26,42 @@ void write_to_byte_array32(uint8_t *ptr, uint32_t value);
 
 void core_dump();
 
-void unimplemented(const std::string what, const std::source_location loc = std::source_location::current());
+void unimplemented(const std::string what, const std::source_location loc =
+                                               std::source_location::current());
+
+enum class LogLevel {
+    Trace,
+    Debug,
+    Info,
+    // Warn,
+    // Error,
+    Critical,
+    Off
+};
+
+void init_logger();
+
+void set_log_file(std::string filepath);
+
+template <typename... Args>
+inline void debug(std::string_view fmt, Args &&...args) {
+    spdlog::debug(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void critical(std::string_view fmt, Args &&...args) {
+    spdlog::debug(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void trace(std::string_view fmt, Args &&...args) {
+    spdlog::trace(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void info(std::string_view fmt, Args &&...args) {
+    spdlog::info(fmt, std::forward<Args>(args)...);
+}
 
 } // namespace Utils
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -30,18 +30,20 @@ void unimplemented(const std::string what, const std::source_location loc =
                                                std::source_location::current());
 
 enum class LogLevel {
-    Trace,
-    Debug,
-    Info,
-    // Warn,
-    // Error,
-    Critical,
-    Off
+    TRACE,
+    DEBUG,
+    INFO,
+    // WARN,
+    // ERROR,
+    CRITICAL,
+    OFF
 };
 
 void init_logger();
 
 void set_log_file(std::string filepath);
+
+void set_log_level(LogLevel level);
 
 template <typename... Args>
 inline void debug(std::string_view fmt, Args &&...args) {

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -52,7 +52,7 @@ inline void debug(std::string_view fmt, Args &&...args) {
 
 template <typename... Args>
 inline void critical(std::string_view fmt, Args &&...args) {
-    spdlog::debug(fmt, std::forward<Args>(args)...);
+    spdlog::critical(fmt, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
@@ -63,6 +63,13 @@ inline void trace(std::string_view fmt, Args &&...args) {
 template <typename... Args>
 inline void info(std::string_view fmt, Args &&...args) {
     spdlog::info(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> void abort(std::string_view fmt, Args &&...args) {
+    spdlog::critical("Abort!");
+    spdlog::critical(fmt, std::forward<Args>(args)...);
+    core_dump();
+    exit(-1);
 }
 
 } // namespace Utils


### PR DESCRIPTION
Fixes https://github.com/kmc-jp/n64-emu/issues/13

ログ関数をUtilsに移動した。今後はspdlogを直接叩かないでください。
さらに、--log-levelオプションを追加した。usageに説明があります。
ログレベルはspdlogに準拠しています。ただし、warnとerrorは使えません。

使用例:
```
.\src\Debug\n64.exe --log output.txt --log-level trace ..\mimi-6126231.z64
```

CPU命令のログをすべてtraceにしたので、`--log-level debug`で出力しないようにできる。こっちのほうが高速。
