### PR TITLE
命令のログを見やすくする

### DIFF
--- a/src/n64_system/n64_system.cpp
+++ b/src/n64_system/n64_system.cpp
@@ -70,7 +70,8 @@ void run(Config config) {
 
         if (g_scheduler().get_current_time() % 0x10'0000 == 0) {
             Utils::set_log_level(Utils::LogLevel::TRACE);
-            Utils::debug("Current time: 0x{:016X}",
+            Utils::debug("");
+            Utils::debug("Current CPU time: 0x{:016X}. showing next trace log",
                          g_scheduler().get_current_time());
             Utils::debug("pc = {:#18x}", N64::g_cpu().get_pc64());
         } else if (g_scheduler().get_current_time() % 0x10'0000 == 1) {


### PR DESCRIPTION
こんなかんじ
```
[info] Resetting N64 system
[debug] initializing RDRAM
[debug] reading from ROM
[debug] ROM size	= 4026531840
[debug] imageName	= "mimi controller test"
[debug] CIC	= 3
[info] resetting CPU
[debug] initializing CPU COP0
[info] resetting RSP
[info] resetting PI
[info] resetting PI
[info] Executing PIF ROM
[info] Starting N64 system
[debug] DMA Write: 0x10001000 -> 0x00000400 (len = 0x00100000)
[debug] DMA Write completed
[debug] 
[debug] Current CPU time: 0x0000000000100000. showing next trace log
[debug] pc = 0xffffffff80000140
[trace] 
[trace] CPU cycle starts
[trace] address translation vaddr 0x80000140 => paddr 0x00000140
[trace] fetched inst = 0x00602825 from pc = 0xffffffff80000140
[trace] OR: a1 <= v1 | zero
[debug] 
[debug] Current CPU time: 0x0000000000200000. showing next trace log
[debug] pc = 0xffffffff80000154
[trace] 
[trace] CPU cycle starts
[trace] address translation vaddr 0x80000154 => paddr 0x00000154
[trace] fetched inst = 0x00627004 from pc = 0xffffffff80000154
[trace] SLLV t6, v0, v1
[debug] 
[debug] Current CPU time: 0x0000000000300000. showing next trace log
[debug] pc = 0xffffffff80000164
[trace] 
[trace] CPU cycle starts
[trace] address translation vaddr 0x80000164 => paddr 0x00000164
[trace] fetched inst = 0x01625826 from pc = 0xffffffff80000164
[trace] XOR: t3 <= t3 ^ v0
[debug] 
[debug] Current CPU time: 0x0000000000400000. showing next trace log
[debug] pc = 0xffffffff80000180
[trace] 
[trace] CPU cycle starts
[trace] address translation vaddr 0x80000180 => paddr 0x00000180
[trace] fetched inst = 0x25080004 from pc = 0xffffffff80000180
[trace] ADDIU: t0 <= t0 + 0x4
[debug] 
[debug] Current CPU time: 0x0000000000500000. showing next trace log
[debug] pc = 0xffffffff80000190
[trace] 
[trace] CPU cycle starts
[trace] address translation vaddr 0x80000190 => paddr 0x00000190
[trace] fetched inst = 0x01ec6021 from pc = 0xffffffff80000190
[trace] ADDU: t4 <= t7 + t4
[debug] 
[debug] Current CPU time: 0x0000000000600000. showing next trace log
[debug] pc = 0xffffffff800001c8
[trace] 
[trace] CPU cycle starts
[trace] address translation vaddr 0x800001c8 => paddr 0x000001c8
[trace] fetched inst = 0x0411ffff from pc = 0xffffffff800001c8
[trace] BLTZAL cond: zero >= 0
[trace] pc <= pc -0x4?
[trace] branch taken
[debug] 
[debug] Current CPU time: 0x0000000000700000. showing next trace log
[debug] pc = 0xffffffff800001c8
[trace] 
[trace] CPU cycle starts
[trace] address translation vaddr 0x800001c8 => paddr 0x000001c8
[trace] fetched inst = 0x0411ffff from pc = 0xffffffff800001c8
[trace] BLTZAL cond: zero >= 0
[trace] pc <= pc -0x4?
[trace] branch taken
[debug] 
```